### PR TITLE
fix/OAuth login now stores the requested downstream audience plus red…

### DIFF
--- a/app/core/browser_sessions.py
+++ b/app/core/browser_sessions.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 from fastapi import Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 from starlette.responses import Response
 
 from app.config import get_settings
@@ -298,4 +298,19 @@ def build_cookie_reauth_response(*, access_token: str, status_code: int = 200) -
         content={"authenticated": True, "session_transport": "cookie"},
     )
     set_access_cookie(response, access_token)
+    return response
+
+
+def build_cookie_session_redirect_response(
+    *,
+    redirect_url: str,
+    access_token: str,
+    refresh_token: str,
+    status_code: int = 303,
+) -> RedirectResponse:
+    """Build a redirect response that also establishes browser-session cookies."""
+    response = RedirectResponse(url=redirect_url, status_code=status_code)
+    set_access_cookie(response, access_token)
+    set_refresh_cookie(response, refresh_token)
+    set_csrf_cookie(response, mint_csrf_token())
     return response

--- a/app/routers/oauth.py
+++ b/app/routers/oauth.py
@@ -8,6 +8,10 @@ from fastapi import APIRouter, Depends, Query, Request, Response
 from fastapi.responses import JSONResponse, RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.browser_sessions import (
+    build_cookie_session_redirect_response,
+    get_browser_session_settings,
+)
 from app.dependencies import get_database_session
 from app.schemas.token import TokenPairResponse
 from app.services.audit_service import AuditService, get_audit_service
@@ -22,6 +26,14 @@ def _error_response(status_code: int, detail: str, code: str) -> JSONResponse:
     return JSONResponse(status_code=status_code, content={"detail": detail, "code": code})
 
 
+def _normalized_optional_attr(value: object) -> str | None:
+    """Normalize optional redirect-like attributes without stringifying None."""
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
 @router.get("/google/login")
 async def google_login(
     request: Request,
@@ -29,10 +41,14 @@ async def google_login(
     oauth_service: Annotated[OAuthService, Depends(get_oauth_service)],
     audit_service: Annotated[AuditService, Depends(get_audit_service)],
     redirect_uri: Annotated[str | None, Query()] = None,
+    audience: Annotated[str | None, Query(min_length=1, max_length=255)] = None,
 ) -> Response:
     """Initiate Google OAuth flow with server-side state storage."""
     try:
-        authorization_url = await oauth_service.build_google_login_url(redirect_uri=redirect_uri)
+        authorization_url = await oauth_service.build_google_login_url(
+            redirect_uri=redirect_uri,
+            audience=audience,
+        )
     except OAuthServiceError as exc:
         await audit_service.record(
             db=db_session,
@@ -59,7 +75,7 @@ async def google_callback(
 ) -> TokenPairResponse | JSONResponse:
     """Complete Google OAuth callback and issue auth tokens."""
     try:
-        token_pair = await oauth_service.complete_google_callback(
+        completion = await oauth_service.complete_google_callback(
             db_session=db_session,
             state=state,
             code=code,
@@ -104,7 +120,14 @@ async def google_callback(
         request=request,
         metadata={"provider": "google", "token_kind": "access_refresh_pair"},
     )
+    redirect_uri = _normalized_optional_attr(getattr(completion, "redirect_uri", None))
+    if redirect_uri is not None and get_browser_session_settings().enabled:
+        return build_cookie_session_redirect_response(
+            redirect_url=redirect_uri,
+            access_token=completion.access_token,
+            refresh_token=completion.refresh_token,
+        )
     return TokenPairResponse(
-        access_token=token_pair.access_token,
-        refresh_token=token_pair.refresh_token,
+        access_token=completion.access_token,
+        refresh_token=completion.refresh_token,
     )

--- a/app/routers/saml.py
+++ b/app/routers/saml.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 from typing import Annotated
-from urllib.parse import parse_qs
+from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
 
 from fastapi import APIRouter, Depends, Query, Request, Response
 from fastapi.responses import JSONResponse, RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.browser_sessions import (
+    build_cookie_session_redirect_response,
+    get_browser_session_settings,
+)
 from app.core.saml import build_saml_request_data
 from app.dependencies import get_database_session
 from app.schemas.token import TokenPairResponse
@@ -39,6 +43,24 @@ async def _post_form_to_dict(request: Request) -> dict[str, str]:
     return {key: values[-1] for key, values in parsed.items() if values}
 
 
+def _append_query_params(url: str, **params: str) -> str:
+    """Append query parameters to a URL while preserving existing values."""
+    parsed = urlsplit(url)
+    existing = parse_qs(parsed.query, keep_blank_values=True)
+    for key, value in params.items():
+        existing[key] = [value]
+    merged_query = urlencode(existing, doseq=True)
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, merged_query, parsed.fragment))
+
+
+def _normalized_optional_attr(value: object) -> str | None:
+    """Normalize optional redirect-like attributes without stringifying None."""
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
 @router.get("/login", response_model=None)
 async def saml_login(
     request: Request,
@@ -46,12 +68,15 @@ async def saml_login(
     saml_service: Annotated[SamlService, Depends(get_saml_service)],
     audit_service: Annotated[AuditService, Depends(get_audit_service)],
     relay_state: Annotated[str | None, Query()] = None,
+    audience: Annotated[str | None, Query(min_length=1, max_length=255)] = None,
 ) -> Response:
     """Initiate SAML authentication request."""
     request_data = build_saml_request_data(request=request, get_data=_query_to_dict(request))
     try:
         redirect_url = await saml_service.create_login_url(
-            request_data=request_data, relay_state=relay_state
+            request_data=request_data,
+            relay_state=relay_state,
+            audience=audience,
         )
     except SamlServiceError as exc:
         await audit_service.record(
@@ -80,7 +105,7 @@ async def saml_callback(
     post_data = await _post_form_to_dict(request) if request.method.upper() == "POST" else {}
     request_data = build_saml_request_data(request=request, get_data=get_data, post_data=post_data)
     try:
-        token_pair = await saml_service.complete_callback(
+        completion = await saml_service.complete_callback(
             db_session=db_session,
             request_data=request_data,
         )
@@ -124,9 +149,22 @@ async def saml_callback(
         request=request,
         metadata={"provider": "saml", "token_kind": "access_refresh_pair"},
     )
+    redirect_uri = _normalized_optional_attr(getattr(completion, "redirect_uri", None))
+    relay_state = _normalized_optional_attr(getattr(completion, "relay_state", None))
+    if redirect_uri is not None and get_browser_session_settings().enabled:
+        redirect_url = (
+            _append_query_params(redirect_uri, relay_state=relay_state)
+            if relay_state is not None
+            else redirect_uri
+        )
+        return build_cookie_session_redirect_response(
+            redirect_url=redirect_url,
+            access_token=completion.access_token,
+            refresh_token=completion.refresh_token,
+        )
     return TokenPairResponse(
-        access_token=token_pair.access_token,
-        refresh_token=token_pair.refresh_token,
+        access_token=completion.access_token,
+        refresh_token=completion.refresh_token,
     )
 
 

--- a/app/services/oauth_service.py
+++ b/app/services/oauth_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hmac
 import inspect
 import json
 from dataclasses import dataclass
@@ -13,7 +14,7 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import reloadable_singleton
+from app.config import get_settings, reloadable_singleton
 from app.core.callable_compat import add_supported_kwarg, get_callable_parameter_names
 from app.core.oauth import GoogleOAuthClient, OAuthProtocolError, get_google_oauth_client
 from app.core.sessions import SessionService, get_redis_client, get_session_service
@@ -28,6 +29,26 @@ class OAuthStateRecord:
     nonce: str
     code_verifier: str
     redirect_uri: str
+    return_redirect_uri: str | None = None
+    audience: str | None = None
+
+
+@dataclass(frozen=True)
+class OAuthCallbackCompletion:
+    """Completed OAuth login result including optional caller redirect context."""
+
+    token_pair: TokenPair
+    redirect_uri: str | None = None
+
+    @property
+    def access_token(self) -> str:
+        """Expose access token for compatibility with token-pair call sites."""
+        return self.token_pair.access_token
+
+    @property
+    def refresh_token(self) -> str:
+        """Expose refresh token for compatibility with token-pair call sites."""
+        return self.token_pair.refresh_token
 
 
 class OAuthServiceError(Exception):
@@ -57,11 +78,13 @@ return value
         redis_client: Redis,
         token_service: TokenService,
         session_service: SessionService,
+        allowed_redirect_uris: tuple[str, ...] = (),
     ) -> None:
         self._oauth_client = oauth_client
         self._redis = redis_client
         self._token_service = token_service
         self._session_service = session_service
+        self._allowed_redirect_uris = allowed_redirect_uris
         self._state_ttl_seconds = 600
 
     def _issue_token_pair(
@@ -73,6 +96,7 @@ return value
         email_verified: bool,
         email_otp_enabled: bool,
         scopes: list[str],
+        audience: str | None = None,
     ):
         """Issue token pair while tolerating legacy test doubles."""
         issue_method = self._token_service.issue_token_pair
@@ -98,12 +122,28 @@ return value
             name="email_otp_enabled",
             value=email_otp_enabled,
         )
+        add_supported_kwarg(
+            kwargs,
+            supported_parameters=supported_parameters,
+            name="audience",
+            value=audience,
+        )
+        add_supported_kwarg(
+            kwargs,
+            supported_parameters=supported_parameters,
+            name="audiences",
+            value=audience,
+        )
         return issue_method(**kwargs)
 
-    async def build_google_login_url(self, redirect_uri: str | None) -> str:
+    async def build_google_login_url(
+        self,
+        redirect_uri: str | None,
+        audience: str | None = None,
+    ) -> str:
         """Create Google login URL and persist one-time state in Redis."""
         try:
-            resolved_redirect_uri = self._oauth_client.resolve_redirect_uri(redirect_uri)
+            provider_redirect_uri = self._oauth_client.resolve_redirect_uri(None)
             state = self._oauth_client.generate_state()
             nonce = self._oauth_client.generate_nonce()
             code_verifier = self._oauth_client.generate_code_verifier()
@@ -112,7 +152,9 @@ return value
         state_record = OAuthStateRecord(
             nonce=nonce,
             code_verifier=code_verifier,
-            redirect_uri=resolved_redirect_uri,
+            redirect_uri=provider_redirect_uri,
+            return_redirect_uri=self._resolve_post_auth_redirect_uri(redirect_uri),
+            audience=self._normalize_optional_string(audience),
         )
         await self._store_state(state=state, record=state_record)
         try:
@@ -120,7 +162,7 @@ return value
                 state=state,
                 nonce=nonce,
                 code_verifier=code_verifier,
-                redirect_uri=resolved_redirect_uri,
+                redirect_uri=provider_redirect_uri,
             )
         except OAuthProtocolError as exc:
             raise OAuthServiceError(exc.detail, exc.code, exc.status_code) from exc
@@ -130,17 +172,14 @@ return value
         db_session: AsyncSession,
         state: str,
         code: str,
-    ) -> TokenPair:
+    ) -> OAuthCallbackCompletion:
         """Complete OAuth callback and return access/refresh token pair."""
         state_record = await self._consume_state(state=state)
         try:
-            resolved_redirect_uri = self._oauth_client.resolve_redirect_uri(
-                state_record.redirect_uri
-            )
             token_payload = await self._oauth_client.exchange_code_for_tokens(
                 code=code,
                 code_verifier=state_record.code_verifier,
-                redirect_uri=resolved_redirect_uri,
+                redirect_uri=state_record.redirect_uri,
             )
         except OAuthProtocolError as exc:
             raise OAuthServiceError(exc.detail, exc.code, exc.status_code) from exc
@@ -174,6 +213,7 @@ return value
             email_verified=user.email_verified,
             email_otp_enabled=user.email_otp_enabled,
             scopes=[],
+            audience=state_record.audience,
         )
         token_pair = await issued_pair if inspect.isawaitable(issued_pair) else issued_pair
         await self._session_service.create_login_session(
@@ -187,7 +227,10 @@ return value
             raw_access_token=token_pair.access_token,
             raw_refresh_token=token_pair.refresh_token,
         )
-        return token_pair
+        return OAuthCallbackCompletion(
+            token_pair=token_pair,
+            redirect_uri=state_record.return_redirect_uri,
+        )
 
     async def _upsert_identity_then_resolve_user(
         self,
@@ -378,6 +421,8 @@ return value
                         "nonce": record.nonce,
                         "code_verifier": record.code_verifier,
                         "redirect_uri": record.redirect_uri,
+                        "return_redirect_uri": record.return_redirect_uri,
+                        "audience": record.audience,
                     }
                 ),
             )
@@ -408,13 +453,33 @@ return value
         """Build Redis key for OAuth state payload."""
         return f"oauth_state:{state}"
 
+    def _resolve_post_auth_redirect_uri(self, redirect_uri: str | None) -> str | None:
+        """Validate an optional post-auth redirect target against the allowlist."""
+        candidate = self._normalize_optional_string(redirect_uri)
+        if candidate is None:
+            return None
+        for allowed in self._allowed_redirect_uris:
+            if hmac.compare_digest(candidate, allowed):
+                return candidate
+        raise OAuthServiceError("Invalid redirect URI.", "invalid_credentials", 400)
+
+    @staticmethod
+    def _normalize_optional_string(value: str | None) -> str | None:
+        """Normalize optional string inputs and treat blanks as missing."""
+        if value is None:
+            return None
+        normalized = value.strip()
+        return normalized or None
+
 
 @reloadable_singleton
 def get_oauth_service() -> OAuthService:
     """Build and cache OAuth service dependencies."""
+    settings = get_settings()
     return OAuthService(
         oauth_client=get_google_oauth_client(),
         redis_client=get_redis_client(),
         token_service=get_token_service(),
         session_service=get_session_service(),
+        allowed_redirect_uris=tuple(str(uri) for uri in settings.oauth.redirect_uri_allowlist),
     )

--- a/app/services/saml_service.py
+++ b/app/services/saml_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hmac
 import inspect
 import json
 import secrets
@@ -13,7 +14,7 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import reloadable_singleton
+from app.config import get_settings, reloadable_singleton
 from app.core.callable_compat import add_supported_kwarg, get_callable_parameter_names
 from app.core.saml import SamlCore, SamlProtocolError, get_saml_core
 from app.core.sessions import SessionService, get_redis_client, get_session_service
@@ -36,6 +37,28 @@ class SamlStateRecord:
     """Serialized SAML request state stored in Redis."""
 
     request_id: str
+    redirect_uri: str | None = None
+    relay_state: str | None = None
+    audience: str | None = None
+
+
+@dataclass(frozen=True)
+class SamlCallbackCompletion:
+    """Completed SAML login result including optional caller context."""
+
+    token_pair: TokenPair
+    redirect_uri: str | None = None
+    relay_state: str | None = None
+
+    @property
+    def access_token(self) -> str:
+        """Expose access token for compatibility with token-pair call sites."""
+        return self.token_pair.access_token
+
+    @property
+    def refresh_token(self) -> str:
+        """Expose refresh token for compatibility with token-pair call sites."""
+        return self.token_pair.refresh_token
 
 
 class SamlService:
@@ -55,11 +78,13 @@ return value
         token_service: TokenService,
         session_service: SessionService,
         redis_client: Redis,
+        allowed_redirect_uris: tuple[str, ...] = (),
     ) -> None:
         self._saml_core = saml_core
         self._token_service = token_service
         self._session_service = session_service
         self._redis = redis_client
+        self._allowed_redirect_uris = allowed_redirect_uris
         self._state_ttl_seconds = 600
 
     def _issue_token_pair(
@@ -71,6 +96,7 @@ return value
         email_verified: bool,
         email_otp_enabled: bool,
         scopes: list[str],
+        audience: str | None = None,
     ):
         """Issue token pair while tolerating legacy test doubles."""
         issue_method = self._token_service.issue_token_pair
@@ -96,10 +122,29 @@ return value
             name="email_otp_enabled",
             value=email_otp_enabled,
         )
+        add_supported_kwarg(
+            kwargs,
+            supported_parameters=supported_parameters,
+            name="audience",
+            value=audience,
+        )
+        add_supported_kwarg(
+            kwargs,
+            supported_parameters=supported_parameters,
+            name="audiences",
+            value=audience,
+        )
         return issue_method(**kwargs)
 
-    async def create_login_url(self, request_data: dict[str, str], relay_state: str | None) -> str:
+    async def create_login_url(
+        self,
+        request_data: dict[str, str],
+        relay_state: str | None,
+        audience: str | None = None,
+    ) -> str:
         """Create SAML login redirect URL."""
+        normalized_relay_state = self._normalize_optional_string(relay_state)
+        redirect_uri = self._resolve_post_auth_redirect_uri(normalized_relay_state)
         try:
             state_token = self._generate_state_token()
             login_request = self._saml_core.login_url(
@@ -110,7 +155,12 @@ return value
             raise SamlServiceError(exc.detail, exc.code, exc.status_code) from exc
         await self._store_state(
             state=state_token,
-            record=SamlStateRecord(request_id=login_request.request_id),
+            record=SamlStateRecord(
+                request_id=login_request.request_id,
+                redirect_uri=redirect_uri,
+                relay_state=None if redirect_uri is not None else normalized_relay_state,
+                audience=self._normalize_optional_string(audience),
+            ),
         )
         return login_request.redirect_url
 
@@ -118,7 +168,7 @@ return value
         self,
         db_session: AsyncSession,
         request_data: dict[str, str],
-    ) -> TokenPair:
+    ) -> SamlCallbackCompletion:
         """Validate SAML assertion, resolve identity, and issue tokens."""
         relay_state = self._extract_relay_state(request_data)
         state_record = await self._consume_state(relay_state)
@@ -144,6 +194,7 @@ return value
             email_verified=user.email_verified,
             email_otp_enabled=user.email_otp_enabled,
             scopes=[],
+            audience=state_record.audience,
         )
         token_pair = await issued_pair if inspect.isawaitable(issued_pair) else issued_pair
         await self._session_service.create_login_session(
@@ -157,7 +208,11 @@ return value
             raw_access_token=token_pair.access_token,
             raw_refresh_token=token_pair.refresh_token,
         )
-        return token_pair
+        return SamlCallbackCompletion(
+            token_pair=token_pair,
+            redirect_uri=state_record.redirect_uri,
+            relay_state=state_record.relay_state,
+        )
 
     def metadata_xml(self) -> str:
         """Return current SP metadata XML."""
@@ -349,7 +404,14 @@ return value
             await self._redis.setex(
                 self._state_key(state),
                 self._state_ttl_seconds,
-                json.dumps({"request_id": record.request_id}),
+                json.dumps(
+                    {
+                        "request_id": record.request_id,
+                        "redirect_uri": record.redirect_uri,
+                        "relay_state": record.relay_state,
+                        "audience": record.audience,
+                    }
+                ),
             )
         except RedisError as exc:
             raise SamlServiceError(
@@ -405,13 +467,32 @@ return value
         """Build Redis key for one-time SAML request state."""
         return f"saml_state:{state}"
 
+    def _resolve_post_auth_redirect_uri(self, redirect_uri: str | None) -> str | None:
+        """Validate an optional post-auth redirect target against the allowlist."""
+        if redirect_uri is None:
+            return None
+        for allowed in self._allowed_redirect_uris:
+            if hmac.compare_digest(redirect_uri, allowed):
+                return redirect_uri
+        return None
+
+    @staticmethod
+    def _normalize_optional_string(value: str | None) -> str | None:
+        """Normalize optional string inputs and treat blanks as missing."""
+        if value is None:
+            return None
+        normalized = value.strip()
+        return normalized or None
+
 
 @reloadable_singleton
 def get_saml_service() -> SamlService:
     """Create and cache SAML service dependency."""
+    settings = get_settings()
     return SamlService(
         saml_core=get_saml_core(),
         token_service=get_token_service(),
         session_service=get_session_service(),
         redis_client=get_redis_client(),
+        allowed_redirect_uris=tuple(str(uri) for uri in settings.oauth.redirect_uri_allowlist),
     )

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,7 +24,10 @@ Examples:
 
 ```text
 APP__ALLOWED_HOSTS=["auth.example.com","api.auth.example.com"]
-OAUTH__REDIRECT_URI_ALLOWLIST=["https://app.example.com/callback"]
+OAUTH__REDIRECT_URI_ALLOWLIST=[
+  "https://auth.example.com/auth/oauth/google/callback",
+  "https://app.example.com/post-auth"
+]
 ```
 
 ## Required Baseline Settings
@@ -129,6 +132,8 @@ Forbidden in production:
 - `OAUTH__GOOGLE_CLIENT_SECRET`
 - `OAUTH__GOOGLE_REDIRECT_URI`
 - `OAUTH__REDIRECT_URI_ALLOWLIST`
+  include the auth-service Google callback URI and any browser post-auth return
+  URLs that should be accepted for OAuth or SAML completion redirects
 
 ### SAML
 

--- a/docs/service-api.md
+++ b/docs/service-api.md
@@ -68,6 +68,19 @@ Application errors follow the same basic structure:
 - `GET /auth/saml/login`
 - `GET /auth/saml/metadata`
 
+Federated browser-flow notes:
+
+- `GET /auth/oauth/google/login` accepts optional `redirect_uri` and `audience`
+  query params
+- `GET /auth/saml/login` accepts optional `relay_state` and `audience` query
+  params
+- when browser sessions are enabled and caller redirect context is supplied,
+  the callback completes by setting auth cookies and returning `303 See Other`
+  to the caller instead of a raw JSON token pair
+- OAuth validates `redirect_uri` against the configured allowlist
+- SAML preserves opaque `relay_state`; when `relay_state` is an allowlisted
+  absolute URL, it is treated as the browser return target
+
 ### User API Keys
 
 - `POST /auth/apikeys`

--- a/tests/integration/test_audit_events_real.py
+++ b/tests/integration/test_audit_events_real.py
@@ -74,8 +74,12 @@ class _OAuthClientStub:
 class _FailingOAuthService:
     """OAuth service stub that fails login start."""
 
-    async def build_google_login_url(self, redirect_uri: str | None) -> str:
-        del redirect_uri
+    async def build_google_login_url(
+        self,
+        redirect_uri: str | None,
+        audience: str | None = None,
+    ) -> str:
+        del redirect_uri, audience
         raise OAuthServiceError("OAuth state mismatch.", "oauth_state_mismatch", 503)
 
     async def complete_google_callback(self, db_session: AsyncSession, state: str, code: str):

--- a/tests/integration/test_oauth_router.py
+++ b/tests/integration/test_oauth_router.py
@@ -33,8 +33,13 @@ class _OAuthServiceStub:
         self.login_url = login_url
         self.callback_result = callback_result
 
-    async def build_google_login_url(self, redirect_uri: str | None) -> str:
+    async def build_google_login_url(
+        self,
+        redirect_uri: str | None,
+        audience: str | None = None,
+    ) -> str:
         """Return deterministic login URL for redirect tests."""
+        del redirect_uri, audience
         return self.login_url
 
     async def complete_google_callback(

--- a/tests/integration/test_oauth_router_real.py
+++ b/tests/integration/test_oauth_router_real.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from http.cookies import SimpleCookie
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -80,7 +81,29 @@ def _build_oauth_service() -> OAuthService:
         redis_client=get_redis_client(),
         token_service=get_token_service(),
         session_service=get_session_service(),
+        allowed_redirect_uris=(),
     )
+
+
+def _build_oauth_service_with_redirects(*allowed_redirect_uris: str) -> OAuthService:
+    """Build OAuth service with explicit post-auth redirect allowlist for browser-flow tests."""
+    return OAuthService(
+        oauth_client=_OAuthClientStub(),
+        redis_client=get_redis_client(),
+        token_service=get_token_service(),
+        session_service=get_session_service(),
+        allowed_redirect_uris=allowed_redirect_uris,
+    )
+
+
+def _cookie_value(response, cookie_name: str) -> str:
+    """Extract one cookie value from the response Set-Cookie headers."""
+    for header in response.headers.get_list("set-cookie"):
+        parsed = SimpleCookie()
+        parsed.load(header)
+        if cookie_name in parsed:
+            return parsed[cookie_name].value
+    raise AssertionError(f"Missing Set-Cookie header for {cookie_name}.")
 
 
 @pytest.mark.asyncio
@@ -113,6 +136,52 @@ async def test_oauth_google_login_and_callback_success(app_factory, db_session) 
         )
     ).scalar_one()
     assert user.email_verified is True
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_oauth_google_callback_redirects_browser_flow_with_requested_audience(
+    app_factory,
+) -> None:
+    """OAuth browser flows should set cookies, preserve caller redirect, and honor audience."""
+    app: FastAPI = app_factory()
+    app.dependency_overrides[get_oauth_service] = lambda: _build_oauth_service_with_redirects(
+        "http://app.example.com/post-auth"
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        login_response = await client.get(
+            "/auth/oauth/google/login",
+            params={
+                "redirect_uri": "http://app.example.com/post-auth",
+                "audience": "orders-api",
+            },
+        )
+        state = parse_qs(urlparse(login_response.headers["location"]).query)["state"][0]
+
+        callback_response = await client.get(
+            "/auth/oauth/google/callback",
+            params={"state": state, "code": "oauthcode"},
+        )
+
+    assert callback_response.status_code == 303
+    assert callback_response.headers["location"] == "http://app.example.com/post-auth"
+
+    access_cookie = _cookie_value(callback_response, "auth_access")
+    refresh_cookie = _cookie_value(callback_response, "auth_refresh")
+    csrf_cookie = _cookie_value(callback_response, "auth_csrf")
+
+    assert access_cookie
+    assert refresh_cookie
+    assert csrf_cookie
+    claims = get_jwt_service().verify_token(
+        access_cookie,
+        expected_type="access",
+        expected_audience="orders-api",
+    )
+    assert claims["email_verified"] is True
     app.dependency_overrides.clear()
 
 

--- a/tests/integration/test_saml_router.py
+++ b/tests/integration/test_saml_router.py
@@ -33,9 +33,14 @@ class _SamlServiceStub:
         self.callback_result = callback_result
         self.metadata = metadata
 
-    async def create_login_url(self, request_data: dict[str, str], relay_state: str | None) -> str:
+    async def create_login_url(
+        self,
+        request_data: dict[str, str],
+        relay_state: str | None,
+        audience: str | None = None,
+    ) -> str:
         """Return deterministic redirect URL."""
-        del request_data, relay_state
+        del request_data, relay_state, audience
         return "https://idp.example.com/sso"
 
     async def complete_callback(

--- a/tests/integration/test_saml_router_real.py
+++ b/tests/integration/test_saml_router_real.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from http.cookies import SimpleCookie
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
 
+from app.core.jwt import get_jwt_service
 from app.core.saml import SamlAssertion, SamlLoginRequest, SamlProtocolError
 from app.core.sessions import get_redis_client, get_session_service
 from app.models.user import User, UserIdentity
@@ -60,7 +63,29 @@ def _build_saml_service(mode: str = "success") -> SamlService:
         token_service=get_token_service(),
         session_service=get_session_service(),
         redis_client=get_redis_client(),
+        allowed_redirect_uris=(),
     )
+
+
+def _build_saml_service_with_redirects(*allowed_redirect_uris: str) -> SamlService:
+    """Build SAML service with an explicit browser redirect allowlist."""
+    return SamlService(
+        saml_core=_SamlCoreStub(mode="success"),
+        token_service=get_token_service(),
+        session_service=get_session_service(),
+        redis_client=get_redis_client(),
+        allowed_redirect_uris=allowed_redirect_uris,
+    )
+
+
+def _cookie_value(response, cookie_name: str) -> str:
+    """Extract one cookie value from the response Set-Cookie headers."""
+    for header in response.headers.get_list("set-cookie"):
+        parsed = SimpleCookie()
+        parsed.load(header)
+        if cookie_name in parsed:
+            return parsed[cookie_name].value
+    raise AssertionError(f"Missing Set-Cookie header for {cookie_name}.")
 
 
 @pytest.mark.asyncio
@@ -89,6 +114,53 @@ async def test_saml_login_callback_and_metadata_success(app_factory) -> None:
 
     assert metadata_response.status_code == 200
     assert "X509Certificate" in metadata_response.text
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_saml_callback_redirects_browser_flow_and_honors_requested_audience(
+    app_factory,
+) -> None:
+    """SAML browser flows should preserve caller relay context, set cookies, and honor audience."""
+    app: FastAPI = app_factory()
+    app.dependency_overrides[get_saml_service] = lambda: _build_saml_service_with_redirects(
+        "http://app.example.com/post-auth"
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        login_response = await client.get(
+            "/auth/saml/login",
+            params={
+                "relay_state": "http://app.example.com/post-auth",
+                "audience": "orders-api",
+            },
+        )
+        relay_state = parse_qs(urlparse(login_response.headers["location"]).query)["RelayState"][0]
+        assert relay_state != "http://app.example.com/post-auth"
+
+        callback_response = await client.post(
+            "/auth/saml/callback",
+            content=f"SAMLResponse=fake&RelayState={relay_state}",
+            headers={"content-type": "application/x-www-form-urlencoded"},
+        )
+
+    assert callback_response.status_code == 303
+    assert callback_response.headers["location"] == "http://app.example.com/post-auth"
+
+    access_cookie = _cookie_value(callback_response, "auth_access")
+    refresh_cookie = _cookie_value(callback_response, "auth_refresh")
+    csrf_cookie = _cookie_value(callback_response, "auth_csrf")
+
+    assert access_cookie
+    assert refresh_cookie
+    assert csrf_cookie
+    get_jwt_service().verify_token(
+        access_cookie,
+        expected_type="access",
+        expected_audience="orders-api",
+    )
     app.dependency_overrides.clear()
 
 

--- a/tests/unit/test_browser_sessions.py
+++ b/tests/unit/test_browser_sessions.py
@@ -6,6 +6,7 @@ import pytest
 from starlette.responses import Response
 
 from app.core.browser_sessions import (
+    build_cookie_session_redirect_response,
     build_cookie_session_response,
     get_browser_session_settings,
     set_access_cookie,
@@ -60,3 +61,23 @@ def test_build_cookie_session_response_sets_persistent_auth_cookies() -> None:
 
     assert "max-age=900" in access_header.lower()
     assert "max-age=604800" in refresh_header.lower()
+
+
+def test_build_cookie_session_redirect_response_sets_auth_and_csrf_cookies() -> None:
+    """Federated browser completions should redirect while minting session and CSRF cookies."""
+    response = build_cookie_session_redirect_response(
+        redirect_url="https://app.example.com/post-auth",
+        access_token="access-token",
+        refresh_token="refresh-token",
+    )
+
+    settings = get_browser_session_settings()
+    access_header = _header_for_cookie(response, settings.access_cookie_name)
+    refresh_header = _header_for_cookie(response, settings.refresh_cookie_name)
+    csrf_header = _header_for_cookie(response, settings.csrf_cookie_name)
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "https://app.example.com/post-auth"
+    assert "max-age=900" in access_header.lower()
+    assert "max-age=604800" in refresh_header.lower()
+    assert "httponly" not in csrf_header.lower()

--- a/tests/unit/test_oauth_saml_audit_events.py
+++ b/tests/unit/test_oauth_saml_audit_events.py
@@ -28,9 +28,13 @@ class _TokenPairStub:
 class _OAuthServiceStub:
     """OAuth service stub for router audit tests."""
 
-    async def build_google_login_url(self, redirect_uri: str | None) -> str:
+    async def build_google_login_url(
+        self,
+        redirect_uri: str | None,
+        audience: str | None = None,
+    ) -> str:
         """Return deterministic authorization URL."""
-        del redirect_uri
+        del redirect_uri, audience
         return "https://accounts.google.com/o/oauth2/auth?state=test-state"
 
     async def complete_google_callback(
@@ -47,9 +51,14 @@ class _OAuthServiceStub:
 class _SamlServiceStub:
     """SAML service stub for router audit tests."""
 
-    async def create_login_url(self, request_data: dict[str, str], relay_state: str | None) -> str:
+    async def create_login_url(
+        self,
+        request_data: dict[str, str],
+        relay_state: str | None,
+        audience: str | None = None,
+    ) -> str:
         """Return deterministic IdP redirect URL."""
-        del request_data, relay_state
+        del request_data, relay_state, audience
         return "https://idp.example.com/sso"
 
     async def complete_callback(

--- a/tests/unit/test_oauth_service_additional.py
+++ b/tests/unit/test_oauth_service_additional.py
@@ -177,12 +177,14 @@ def _build_service(
     oauth_client: _OAuthClientStub | None = None,
     redis_client: _RedisStub | None = None,
     session_service: _SessionServiceStub | None = None,
+    allowed_redirect_uris: tuple[str, ...] = (),
 ) -> OAuthService:
     return OAuthService(
         oauth_client=oauth_client or _OAuthClientStub(),  # type: ignore[arg-type]
         redis_client=redis_client or _RedisStub(),  # type: ignore[arg-type]
         token_service=_TokenServiceStub(),  # type: ignore[arg-type]
         session_service=session_service or _SessionServiceStub(),  # type: ignore[arg-type]
+        allowed_redirect_uris=allowed_redirect_uris,
     )
 
 
@@ -206,6 +208,27 @@ async def test_build_google_login_url_maps_protocol_errors() -> None:
     with pytest.raises(OAuthServiceError) as exc_info:
         await service.build_google_login_url(None)
     assert exc_info.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_build_google_login_url_stores_post_auth_redirect_and_requested_audience() -> None:
+    """OAuth login initiation should preserve caller redirect and requested audience in state."""
+    redis_client = _RedisStub()
+    service = _build_service(
+        redis_client=redis_client,
+        allowed_redirect_uris=("https://app.example.com/post-auth",),
+    )
+
+    authorization_url = await service.build_google_login_url(
+        "https://app.example.com/post-auth",
+        audience="orders-api",
+    )
+    state_record = await service._consume_state("state-1")
+
+    assert "redirect_uri=https://service.local/callback" in authorization_url
+    assert state_record.redirect_uri == "https://service.local/callback"
+    assert state_record.return_redirect_uri == "https://app.example.com/post-auth"
+    assert state_record.audience == "orders-api"
 
 
 @pytest.mark.asyncio
@@ -278,8 +301,83 @@ async def test_complete_google_callback_creates_session_after_successful_upsert(
         code="auth-code",
     )
 
-    assert result == TokenPair(access_token="access-token", refresh_token="refresh-token")
+    assert result.access_token == "access-token"
+    assert result.refresh_token == "refresh-token"
+    assert result.redirect_uri is None
     assert session_service.calls[0]["email"] == "oauth@example.com"
+
+
+@pytest.mark.asyncio
+async def test_complete_google_callback_preserves_redirect_context_and_requested_audience() -> None:
+    """OAuth callback should issue the requested audience and surface redirect context."""
+    captured_kwargs: dict[str, object] = {}
+
+    class _AudienceTokenService:
+        async def issue_token_pair(
+            self,
+            *,
+            db_session: object,
+            user_id: str,
+            email: str,
+            role: str,
+            email_verified: bool,
+            email_otp_enabled: bool,
+            scopes: list[str],
+            audience: str | None = None,
+        ) -> TokenPair:
+            captured_kwargs.update(
+                {
+                    "db_session": db_session,
+                    "user_id": user_id,
+                    "email": email,
+                    "role": role,
+                    "email_verified": email_verified,
+                    "email_otp_enabled": email_otp_enabled,
+                    "scopes": scopes,
+                    "audience": audience,
+                }
+            )
+            return TokenPair(access_token="access-token", refresh_token="refresh-token")
+
+    service = OAuthService(
+        oauth_client=_OAuthClientStub(),  # type: ignore[arg-type]
+        redis_client=_RedisStub(),  # type: ignore[arg-type]
+        token_service=_AudienceTokenService(),  # type: ignore[arg-type]
+        session_service=_SessionServiceStub(),  # type: ignore[arg-type]
+        allowed_redirect_uris=("https://app.example.com/post-auth",),
+    )
+
+    async def _consume_state(state: str) -> OAuthStateRecord:
+        del state
+        return OAuthStateRecord(
+            nonce="nonce-1",
+            code_verifier="verifier-1",
+            redirect_uri="https://service.local/callback",
+            return_redirect_uri="https://app.example.com/post-auth",
+            audience="orders-api",
+        )
+
+    async def _upsert(**kwargs: object) -> _UserStub:
+        return _UserStub(
+            id="user-1",
+            email="oauth@example.com",
+            role="user",
+            email_verified=True,
+        )
+
+    service._consume_state = _consume_state  # type: ignore[assignment]
+    service._upsert_identity_then_resolve_user = _upsert  # type: ignore[assignment]
+
+    result = await service.complete_google_callback(
+        db_session=object(),  # type: ignore[arg-type]
+        state="state-1",
+        code="auth-code",
+    )
+
+    assert result.access_token == "access-token"
+    assert result.refresh_token == "refresh-token"
+    assert result.redirect_uri == "https://app.example.com/post-auth"
+    assert captured_kwargs["audience"] == "orders-api"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_saml_service_additional.py
+++ b/tests/unit/test_saml_service_additional.py
@@ -27,17 +27,19 @@ class _SamlCoreStub:
         self.login_error: SamlProtocolError | None = None
         self.parse_error: SamlProtocolError | None = None
         self.metadata_error: SamlProtocolError | None = None
+        self.last_relay_state: str | None = None
 
     def login_url(
         self,
         request_data: dict[str, str],
         relay_state: str | None,
     ) -> SamlLoginRequest:
-        del request_data, relay_state
+        del request_data
         if self.login_error is not None:
             raise self.login_error
+        self.last_relay_state = relay_state
         return SamlLoginRequest(
-            redirect_url="https://idp.example.com/login",
+            redirect_url=f"https://idp.example.com/login?RelayState={relay_state}",
             request_id="request-1",
         )
 
@@ -177,12 +179,14 @@ class _DBSessionStub:
 def _service(
     saml_core: _SamlCoreStub | None = None,
     session_service: _SessionServiceStub | None = None,
+    allowed_redirect_uris: tuple[str, ...] = (),
 ) -> SamlService:
     return SamlService(
         saml_core=saml_core or _SamlCoreStub(),  # type: ignore[arg-type]
         token_service=_TokenServiceStub(),  # type: ignore[arg-type]
         session_service=session_service or _SessionServiceStub(),  # type: ignore[arg-type]
         redis_client=_RedisStub(),  # type: ignore[arg-type]
+        allowed_redirect_uris=allowed_redirect_uris,
     )
 
 
@@ -202,6 +206,43 @@ async def test_create_login_url_and_metadata_map_protocol_failures() -> None:
     with pytest.raises(SamlServiceError) as exc_info:
         service.metadata_xml()
     assert exc_info.value.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_create_login_url_preserves_caller_relay_state_and_requested_audience() -> None:
+    """SAML login initiation should retain caller context even when RelayState is internalized."""
+    saml_core = _SamlCoreStub()
+    service = _service(
+        saml_core=saml_core, allowed_redirect_uris=("https://app.example.com/post-auth",)
+    )
+
+    redirect_url = await service.create_login_url(
+        {},
+        "https://app.example.com/post-auth",
+        audience="orders-api",
+    )
+    relay_state = redirect_url.split("RelayState=", 1)[1]
+    state_record = await service._consume_state(relay_state)
+
+    assert saml_core.last_relay_state == relay_state
+    assert relay_state != "https://app.example.com/post-auth"
+    assert state_record.redirect_uri == "https://app.example.com/post-auth"
+    assert state_record.relay_state is None
+    assert state_record.audience == "orders-api"
+
+
+@pytest.mark.asyncio
+async def test_create_login_url_preserves_opaque_relay_state_when_not_redirect_uri() -> None:
+    """SAML login initiation should keep opaque caller relay state for compatibility."""
+    saml_core = _SamlCoreStub()
+    service = _service(saml_core=saml_core)
+
+    redirect_url = await service.create_login_url({}, "client-flow-state")
+    relay_state = redirect_url.split("RelayState=", 1)[1]
+    state_record = await service._consume_state(relay_state)
+
+    assert state_record.redirect_uri is None
+    assert state_record.relay_state == "client-flow-state"
 
 
 @pytest.mark.asyncio
@@ -240,8 +281,82 @@ async def test_complete_callback_maps_parse_failures_and_creates_session() -> No
         request_data={"post_data": {"SAMLResponse": "ok", "RelayState": "relay-state"}},
     )
 
-    assert result == TokenPair(access_token="access-token", refresh_token="refresh-token")
+    assert result.access_token == "access-token"
+    assert result.refresh_token == "refresh-token"
+    assert result.redirect_uri is None
+    assert result.relay_state is None
     assert session_service.calls[0]["email"] == "saml@example.com"
+
+
+@pytest.mark.asyncio
+async def test_complete_callback_preserves_redirect_context_and_requested_audience() -> None:
+    """SAML callback should issue the requested audience and return caller redirect context."""
+    captured_kwargs: dict[str, object] = {}
+
+    class _AudienceTokenService:
+        async def issue_token_pair(
+            self,
+            *,
+            db_session: object,
+            user_id: str,
+            email: str,
+            role: str,
+            email_verified: bool,
+            email_otp_enabled: bool,
+            scopes: list[str],
+            audience: str | None = None,
+        ) -> TokenPair:
+            captured_kwargs.update(
+                {
+                    "db_session": db_session,
+                    "user_id": user_id,
+                    "email": email,
+                    "role": role,
+                    "email_verified": email_verified,
+                    "email_otp_enabled": email_otp_enabled,
+                    "scopes": scopes,
+                    "audience": audience,
+                }
+            )
+            return TokenPair(access_token="access-token", refresh_token="refresh-token")
+
+    service = SamlService(
+        saml_core=_SamlCoreStub(),  # type: ignore[arg-type]
+        token_service=_AudienceTokenService(),  # type: ignore[arg-type]
+        session_service=_SessionServiceStub(),  # type: ignore[arg-type]
+        redis_client=_RedisStub(),  # type: ignore[arg-type]
+        allowed_redirect_uris=("https://app.example.com/post-auth",),
+    )
+
+    async def _upsert(**kwargs: object) -> _UserStub:
+        return _UserStub(
+            id="user-1",
+            email="saml@example.com",
+            role="user",
+            email_verified=True,
+        )
+
+    service._upsert_identity_then_resolve_user = _upsert  # type: ignore[assignment]
+    await service._store_state(  # type: ignore[attr-defined]
+        state="relay-state",
+        record=SamlStateRecord(
+            request_id="request-1",
+            redirect_uri="https://app.example.com/post-auth",
+            relay_state="client-flow-state",
+            audience="orders-api",
+        ),
+    )
+
+    result = await service.complete_callback(
+        db_session=object(),  # type: ignore[arg-type]
+        request_data={"post_data": {"SAMLResponse": "ok", "RelayState": "relay-state"}},
+    )
+
+    assert result.access_token == "access-token"
+    assert result.refresh_token == "refresh-token"
+    assert result.redirect_uri == "https://app.example.com/post-auth"
+    assert result.relay_state == "client-flow-state"
+    assert captured_kwargs["audience"] == "orders-api"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The new behavior is:

* OAuth login now stores the requested downstream audience plus an allowlisted post-auth redirect_uri.
* SAML now preserves caller relay context instead of discarding it. If relay_state is an allowlisted absolute URL, it becomes the browser return target; otherwise it is preserved as opaque relay state.
* Both callbacks now issue the requested downstream audience token.
* When browser sessions are enabled and caller redirect context exists, the callback sets auth cookies plus a fresh CSRF cookie and returns 303 back to the caller.
* If no caller redirect context is present, the old JSON token-pair fallback still works.